### PR TITLE
Fixes redis storage bug on failed connection

### DIFF
--- a/lib/ledge/storage/redis.lua
+++ b/lib/ledge/storage/redis.lua
@@ -312,6 +312,10 @@ function _M.get_writer(self, res, ttl, onsuccess, onfailure)
         end
 
         local chunk, err, has_esi = reader(buffer_size)
+        if not chunk and err then
+            failed = true
+            failed_reason = "upstream error: " .. err
+        end
 
         if chunk and not failed then  -- We have something to write
             size = size + #chunk


### PR DESCRIPTION
Redis storage would roll back if the initial upstream connection failed,
or if the redis connection itself failed, but not if a long running
upstream connection failed midway. This resulted in truncated content
and is most likely to show up with large binaries.