### PR TITLE
Feature to blacklist cookies from esi evaluation

### DIFF
--- a/README.md
+++ b/README.md
@@ -714,6 +714,7 @@ Must be called during the `init_worker` phase, otherwise background tasks will n
 * [esi_custom_variables](#esi_custom_variables)
 * [esi_max_size](#esi_max_size)
 * [esi_attempt_loopback](#esi_attempt_loopback)
+* [esi_vars_cookie_blacklist](#esi_vars_cookie_blacklist)
 * [esi_disable_third_party_includes](#esi_disable_third_party_includes)
 * [esi_third_party_includes_domain_whitelist](#esi_third_party_includes_domain_whitelist)
 * [enable_collapsed_forwarding](#enable_collapsed_forwarding)
@@ -1063,6 +1064,30 @@ default: `true`
 
 If an ESI subrequest has the same `scheme` and `host` as the parent request, we loopback the connection to the current
 `server_addr` and `server_port` in order to avoid going over network.
+
+[Back to TOC](#handler-configuration-options)
+
+
+#### esi_vars_cookie_blacklist
+
+default: `{}`
+
+Cookie names given here will not be expandable as ESI variables: e.g. `$(HTTP_COOKIE)` or `$(HTTP_COOKIE{foo})`. However they
+are not removed from the request data, and will still be propagated to `<esi:include>` subrequests.
+
+This is useful if your client is sending a sensitive cookie that you don't ever want to accidentally evaluate in server output.
+
+```lua
+require("ledge").create_handler({
+    esi_vars_cookie_blacklist = {
+        secret = true,
+        ["my-secret-cookie"] = true,
+    }
+}):run()
+```
+
+Cookie names are given as the table key with a truthy value, for O(1) runtime lookup.
+
 
 [Back to TOC](#handler-configuration-options)
 

--- a/lib/ledge.lua
+++ b/lib/ledge.lua
@@ -82,6 +82,7 @@ local handler_defaults = setmetatable({
     esi_max_size = 1024 * 1024,  -- (bytes)
     esi_custom_variables = {},
     esi_attempt_loopback = true,
+    esi_vars_cookie_blacklist = {},
 
     esi_disable_third_party_includes = false,
     esi_third_party_includes_domain_whitelist = {},

--- a/t/02-integration/esi.t
+++ b/t/02-integration/esi.t
@@ -3121,10 +3121,11 @@ location /fragment {
 GET /esi_46_prx
 --- more_headers
 Cookie: allowed=yes
+Cookie: also_allowed=yes
 Cookie: not_allowed=no
 --- raw_response_headers_unlike: Surrogate-Control: content="ESI/1.0\"\r\n
 --- response_body
-allowed=yes
+allowed=yes; also_allowed=yes
 yes:
 FRAGMENT:&allowed=yes&not_allowed=
 yes:no

--- a/t/02-integration/esi.t
+++ b/t/02-integration/esi.t
@@ -3079,3 +3079,54 @@ Accept: text/plain
 (.*)"cookie": "foo",
 --- no_error_log
 [error]
+
+
+=== TEST 46: Cookie var blacklist
+--- http_config eval: $::HttpConfig
+--- config
+location /esi_46_prx {
+    rewrite ^(.*)_prx$ $1 break;
+    content_by_lua_block {
+        local handler = require("ledge").create_handler({
+            esi_vars_cookie_blacklist = {
+                not_allowed  = true,
+            },
+        })
+        run(handler)
+    }
+}
+location /esi_46 {
+    default_type text/html;
+    content_by_lua_block {
+        -- Blacklist should apply to expansion in vars
+        ngx.say([[<esi:vars>$(HTTP_COOKIE)</esi:vars>]])
+
+        -- And by key
+        ngx.say([[<esi:vars>$(HTTP_COOKIE{allowed}):$(HTTP_COOKIE{not_allowed})</esi:vars>]])
+
+        -- ...and also in URIs
+        ngx.say([[<esi:include src="/fragment?&allowed=$(HTTP_COOKIE{allowed})&not_allowed=$(HTTP_COOKIE{not_allowed})" />]])
+    }
+}
+location /fragment {
+    content_by_lua_block {
+        ngx.say("FRAGMENT:"..ngx.var.args)
+
+        -- But ALL cookies are still propagated by default to subrequests
+        local cookie = require("resty.cookie").new()
+        ngx.print(cookie:get("allowed") .. ":" .. cookie:get("not_allowed"))
+    }
+}
+--- request
+GET /esi_46_prx
+--- more_headers
+Cookie: allowed=yes
+Cookie: not_allowed=no
+--- raw_response_headers_unlike: Surrogate-Control: content="ESI/1.0\"\r\n
+--- response_body
+allowed=yes
+yes:
+FRAGMENT:&allowed=yes&not_allowed=
+yes:no
+--- no_error_log
+[error]


### PR DESCRIPTION
Cookies will still always be sent to subrequests for ESI includes
(unless disabled in another way), but any cookies blacklisted will not
evaluated in <esi:vars> or inside other esi tags, to prevent accidental
exposure of sensitive data.

This required a little refactoring, which will result in a small
performance increase on pages with lots of ESI cookie expansion.